### PR TITLE
Typos causing 400 bad request fix

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -62,7 +62,7 @@ public class RecommendationRequestController extends ApiController{
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public RecommendationRequest createRecommendationRequest(
-            @Parameter(name= "requestorEmail") @RequestParam String requestorEmail,
+            @Parameter(name= "requesterEmail") @RequestParam String requesterEmail,
             @Parameter(name= "professorEmail") @RequestParam String professorEmail,
             @Parameter(name= "explanation") @RequestParam String explanation,
             @Parameter(name= "dateRequested", description = "in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateRequested") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateRequested,
@@ -72,7 +72,7 @@ public class RecommendationRequestController extends ApiController{
         
         // Create a new RecommendationRequest object
         RecommendationRequest request = RecommendationRequest.builder()
-                                        .requesterEmail(requestorEmail)
+                                        .requesterEmail(requesterEmail)
                                         .professorEmail(professorEmail)
                                         .explanation(explanation)
                                         .dateRequested(dateRequested)

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecomendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecomendationRequestControllerTests.java
@@ -189,7 +189,7 @@ public class RecomendationRequestControllerTests extends ControllerTestCase{
 
         when(recommendationRequestRepository.save(eq(req))).thenReturn(req);
 
-        MvcResult response = mockMvc.perform(post("/api/recommendationrequest/post?requestorEmail=testr@ucsb.edu&professorEmail=testp@ucsb.edu&explanation=testexplanation&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-02-03T00:00:00&done=false").with(csrf()))
+        MvcResult response = mockMvc.perform(post("/api/recommendationrequest/post?requesterEmail=testr@ucsb.edu&professorEmail=testp@ucsb.edu&explanation=testexplanation&dateRequested=2022-01-03T00:00:00&dateNeeded=2022-02-03T00:00:00&done=false").with(csrf()))
                         .andExpect(status().isOk())
                         .andReturn();
 


### PR DESCRIPTION
## Overview

Fixed a typo in the blackened that was causing 400 requests for Recommendation Requests.