### PR TITLE
qs - add (create, edit) page for MenuItemReview

### DIFF
--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
@@ -14,7 +14,7 @@ export default function MenuItemReviewTable({
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/menuitemreviews/edit/${cell.row.values.id}`)
+        navigate(`/menuitemreview/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching
@@ -22,7 +22,7 @@ export default function MenuItemReviewTable({
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/menuitemreviews/all"]
+        ["/api/menuitemreview/all"]
     );
     // Stryker restore all
 

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 
 import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/restaurantUtils"
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/menuItemReviewUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,13 +1,60 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage() {
+export default function MenuItemReviewCreatePage(storybook=false) {
 
-  // Stryker disable all : placeholder for future implementation
+  /*
+  {
+  "itemId": 0,
+  "reviewerEmail": "string",
+  "stars": 0,
+  "dateReviewed": "2023-08-08T23:42:03.345Z",
+  "comments": "string",
+  "id": 0
+  }
+  */
+  const objectToAxiosParams = (menuitemreview) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+      itemId: menuitemreview.itemId,
+      reviewerEmail: menuitemreview.reviewerEmail,
+      stars: menuitemreview.stars,
+      dateReviewed: menuitemreview.dateReviewed,
+      comments: menuitemreview.comments,
+    }
+  });
+
+  const onSuccess = (menuitemreview) => {
+    toast(`New MenuItemReview Created - id: ${menuitemreview.id} itemId: ${menuitemreview.itemId} reviewerEmail: ${menuitemreview.reviewerEmail} stars: ${menuitemreview.stars} dateReviewed: ${menuitemreview.dateReviewed} comments: ${menuitemreview.comments}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/menuitemreview/all"] // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (menuitemreview) => {
+    mutation.mutate(menuitemreview);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New MenuItemReview</h1>
+        <MenuItemReviewForm onSubmit={onSubmit} />
       </div>
     </BasicLayout>
-  )
+  );
 }

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -4,7 +4,7 @@ import { Navigate } from "react-router-dom";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function MenuItemReviewCreatePage(storybook=false) {
+export default function MenuItemReviewCreatePage({storybook=false}) {
 
   /*
   {

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -53,7 +53,7 @@ export default function MenuItemReviewCreatePage(storybook=false) {
     <BasicLayout>
       <div className="pt-2">
         <h1>Create New MenuItemReview</h1>
-        <MenuItemReviewForm onSubmit={onSubmit} />
+        <MenuItemReviewForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -26,10 +26,9 @@ export default function MenuItemReviewEditPage({storybook=false}) {
       url: `/api/menuitemreview`,
       method: "PUT",
       params: {
-        id: id,
+        id: menuitemreview.id,
       },
       data: {
-        // id: menuitemreview.id,
         itemId: menuitemreview.itemId,
         reviewerEmail: menuitemreview.reviewerEmail,
         stars: menuitemreview.stars,
@@ -64,7 +63,7 @@ export default function MenuItemReviewEditPage({storybook=false}) {
           <div className="pt-2">
             <h1>Edit MenuItemReview</h1>
             {
-              menuitemreview && <MenuItemReviewForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={menuitemreview} />
+              menuitemreview && <MenuItemReviewForm submitAction={onSubmit} buttonLabel="Update" initialContents={menuitemreview} />
             }
           </div>
         </BasicLayout>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -11,8 +11,9 @@ export default function MenuItemReviewEditPage({storybook=false}) {
 
   const { data: menuitemreview, error: _error, status: _status } =
     useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
       [`/api/menuitemreview?id=${id}`],
-      {
+      {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
         method: "GET",
         url: `/api/menuitemreview`,
         params: {

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -11,15 +11,24 @@ export default function MenuItemReviewEditPage({storybook=false}) {
 
   const { data: menuitemreview, error: _error, status: _status } =
     useBackend(
-      [`/api/menuitemreview/${id}`],
-      { method: "GET", url: `/api/menuitemreview/${id}` },
+      [`/api/menuitemreview?id=${id}`],
+      {
+        method: "GET",
+        url: `/api/menuitemreview`,
+        params: {
+          id: id,
+        } 
+      },
     );
 
     const objectToAxiosPutParams = (menuitemreview) => ({
-      url: `/api/menuitemreview/${id}`,
-      method: "put",
+      url: `/api/menuitemreview`,
+      method: "PUT",
+      params: {
+        id: id,
+      },
       data: {
-        id: menuitemreview.id,
+        // id: menuitemreview.id,
         itemId: menuitemreview.itemId,
         reviewerEmail: menuitemreview.reviewerEmail,
         stars: menuitemreview.stars,
@@ -36,7 +45,7 @@ export default function MenuItemReviewEditPage({storybook=false}) {
         objectToAxiosPutParams,
         { onSuccess },
         // Stryker disable next-line all : hard to set up test for caching
-        [`/api/menuitemreview/${id}`]
+        [`/api/menuitemreview?id=${id}`]
       );
 
       const { isSuccess } = mutation;
@@ -54,7 +63,7 @@ export default function MenuItemReviewEditPage({storybook=false}) {
           <div className="pt-2">
             <h1>Edit MenuItemReview</h1>
             {
-              menuitemreview && <MenuItemReviewForm submitAction={onSubmit} buttonLabel={"Update"} initialMenuItemReview={menuitemreview} />
+              menuitemreview && <MenuItemReviewForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={menuitemreview} />
             }
           </div>
         </BasicLayout>

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,13 +1,62 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function PlaceholderEditPage() {
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
+export default function MenuItemReviewEditPage({storybook=false}) {
+  let { id } = useParams();
+
+  const { data: menuitemreview, error: _error, status: _status } =
+    useBackend(
+      [`/api/menuitemreview/${id}`],
+      { method: "GET", url: `/api/menuitemreview/${id}` },
+    );
+
+    const objectToAxiosPutParams = (menuitemreview) => ({
+      url: `/api/menuitemreview/${id}`,
+      method: "put",
+      data: {
+        id: menuitemreview.id,
+        itemId: menuitemreview.itemId,
+        reviewerEmail: menuitemreview.reviewerEmail,
+        stars: menuitemreview.stars,
+        dateReviewed: menuitemreview.dateReviewed,
+        comments: menuitemreview.comments,
+      },
+      });
+
+      const onSuccess = (menuitemreview) => {
+        toast(`MenuItemReview Updated - id: ${menuitemreview.id} itemId: ${menuitemreview.itemId} reviewerEmail: ${menuitemreview.reviewerEmail} stars: ${menuitemreview.stars} dateReviewed: ${menuitemreview.dateReviewed} comments: ${menuitemreview.comments}`);
+      }
+
+      const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/menuitemreview/${id}`]
+      );
+
+      const { isSuccess } = mutation;
+
+      const onSubmit = async (menuitemreview) => {
+        mutation.mutate(menuitemreview);
+      }
+
+      if (isSuccess && !storybook) {
+        return <Navigate to="/menuitemreview" />;
+      }
+
+      return (
+        <BasicLayout>
+          <div className="pt-2">
+            <h1>Edit MenuItemReview</h1>
+            {
+              menuitemreview && <MenuItemReviewForm submitAction={onSubmit} buttonLabel={"Update"} initialMenuItemReview={menuitemreview} />
+            }
+          </div>
+        </BasicLayout>
+      )
 }

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/menuitemreview",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewCreatePage from 'main/pages/MenuItemReview/MenuItemReviewCreatePage';
+
+export default {
+    title: 'pages/MenuItemReview/MenuItemReviewCreatePage',
+    component: MenuItemReviewCreatePage,
+};
+
+const Template = () => <MenuItemReviewCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/menuitemreview/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
@@ -11,7 +11,7 @@ export default {
     component: MenuItemReviewEditPage
 };
 
-const Template = (args) => <MenuItemReviewEditPage storybook={true} />;
+const Template = () => <MenuItemReviewEditPage storybook={true} />;
 
 export const Default = Template.bind({});
 Default.parameters = {
@@ -26,7 +26,7 @@ Default.parameters = {
             return res(ctx.json(menuItemReviewFixtures.threeMenuItemReviews));
         }),
         rest.put("/api/menuitemreview", async (req, res, ctx) => {
-            var reqBody = await req.text();
+            let reqBody = await req.text();
             window.alert("PUT: " + req.url + " and body: " + reqBody);
             return res(ctx.status(200), ctx.json({}));
         }),

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import MenuItemReviewEditPage from 'main/pages/MenuItemReview/MenuItemReviewEditPage';
+import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
+
+export default {
+    title: 'pages/MenuItemReview/MenuItemReviewEditPage',
+    component: MenuItemReviewEditPage
+};
+
+const Template = (args) => <MenuItemReviewEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get("/api/currentUser", (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get("/api/systemInfo", (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get("/api/menuitemreview/all", (_req, res, ctx) => {
+            return res(ctx.json(menuItemReviewFixtures.threeMenuItemReviews));
+        }),
+        rest.put("/api/menuitemreview", async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200), ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewEditPage.stories.js
@@ -22,8 +22,8 @@ Default.parameters = {
         rest.get("/api/systemInfo", (_req, res, ctx) => {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
-        rest.get("/api/menuitemreview/all", (_req, res, ctx) => {
-            return res(ctx.json(menuItemReviewFixtures.threeMenuItemReviews));
+        rest.get("/api/menuitemreview", (_req, res, ctx) => {
+            return res(ctx.json(menuItemReviewFixtures.threeMenuItemReviews[0]));
         }),
         rest.put("/api/menuitemreview", async (req, res, ctx) => {
             let reqBody = await req.text();

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
@@ -138,7 +138,7 @@ describe("MenuItemReviewTable tests", () => {
 
         fireEvent.click(editButton);
 
-        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(`/menuitemreviews/edit/${menuItemReviewFixtures.threeMenuItemReviews[0].id}`));
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(`/menuitemreview/edit/${menuItemReviewFixtures.threeMenuItemReviews[0].id}`));
     });
 
     test("Delete button calls delete callback", async () => {

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,63 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("MenuItemReviewCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    }
+    );
 
-        setupUserOnly();
-       
-        // act
+    test("on submit, makes request to backend, and redirects to /menuitemreview", async () => {
+        const queryClient = new QueryClient();
+        const expectedMenuItemReview = {
+            "id": "1337",
+            "itemId": "1337",
+            "reviewerEmail": "testtest@ucsb.edu",
+            "stars": "2",
+            "dateReviewed": "2023-08-04T03:58:55.563Z",
+            "comments": "This is a test review 1337"
+        };
+
+        axiosMock.onPost("/api/menuitemreview/post").reply(202, expectedMenuItemReview);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,10 +73,51 @@ describe("MenuItemReviewCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByLabelText("Item Id")).toBeInTheDocument();
+        });
+
+        const itemIdInput = screen.getByLabelText("Item Id");
+        const reviewerEmailInput = screen.getByLabelText("Reviewer Email");
+        const starsInput = screen.getByLabelText("Stars");
+        const dateReviewedInput = screen.getByLabelText("Date Reviewed");
+        const commentsInput = screen.getByLabelText("Comments");
+
+        // expect all of above to be in the document
+        expect(itemIdInput).toBeInTheDocument();
+        expect(reviewerEmailInput).toBeInTheDocument();
+        expect(starsInput).toBeInTheDocument();
+        expect(dateReviewedInput).toBeInTheDocument();
+        expect(commentsInput).toBeInTheDocument();
+
+        fireEvent.change(itemIdInput, { target: { value: expectedMenuItemReview.itemId } });
+        fireEvent.change(reviewerEmailInput, { target: { value: expectedMenuItemReview.reviewerEmail } });
+        fireEvent.change(starsInput, { target: { value: expectedMenuItemReview.stars } });
+        fireEvent.change(dateReviewedInput, { target: { value: expectedMenuItemReview.dateReviewed } });
+        fireEvent.change(commentsInput, { target: { value: expectedMenuItemReview.comments } });
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        // check params
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "itemId": expectedMenuItemReview.itemId,
+                "reviewerEmail": expectedMenuItemReview.reviewerEmail,
+                "stars": expectedMenuItemReview.stars,
+                "dateReviewed": expectedMenuItemReview.dateReviewed,
+                "comments": expectedMenuItemReview.comments
+            }
+        );
+
+        // check toast
+        expect(mockToast).toHaveBeenCalledWith(`New MenuItemReview Created - id: ${expectedMenuItemReview.id} itemId: ${expectedMenuItemReview.itemId} reviewerEmail: ${expectedMenuItemReview.reviewerEmail} stars: ${expectedMenuItemReview.stars} dateReviewed: ${expectedMenuItemReview.dateReviewed} comments: ${expectedMenuItemReview.comments}`);
+
+        // check navigation
+        expect(mockNavigate).toBeCalledTimes(1);
+        expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreview" });
     });
-
 });
-
-

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -99,48 +99,8 @@ describe("MenuItemReviewEditPage tests", () => {
         });
 
         const queryClient = new QueryClient();
+
         test("Is populated with the data provided", async () => {
-            render(
-                <QueryClientProvider client={queryClient}>
-                    <MemoryRouter>
-                        <MenuItemReviewEditPage />
-                    </MemoryRouter>
-                </QueryClientProvider>
-            );
-
-            await screen.findByTestId("MenuItemReviewForm-id");
-
-            const idField = screen.getByTestId("MenuItemReviewForm-id");
-            const itemIdField = screen.getByTestId("MenuItemReviewForm-item-id");
-            const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewer-email");
-            const starsField = screen.getByTestId("MenuItemReviewForm-stars");
-            const dateReviewedField = screen.getByTestId("MenuItemReviewForm-date-reviewed");
-            const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
-            
-            expect(idField).toBeInTheDocument();
-            expect(itemIdField).toBeInTheDocument();
-            expect(reviewerEmailField).toBeInTheDocument();
-            expect(starsField).toBeInTheDocument();
-            expect(dateReviewedField).toBeInTheDocument();
-            expect(commentsField).toBeInTheDocument();
-
-            expect(idField).toHaveValue("1");
-            expect(itemIdField).toHaveValue("1");
-            expect(reviewerEmailField).toHaveValue("test@ucsb.edu");
-            expect(starsField).toHaveValue("5");
-            expect(dateReviewedField).toHaveValue("2023-08-05T03:58:55.563Z");
-            expect(commentsField).toHaveValue("This is a test review");
-        
-            const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
-            fireEvent.change(commentsField, { target: { value: "This is a test review 2" } });
-            fireEvent.click(submitButton);
-
-            await waitFor(() => expect(mockToast).toBeCalled());
-            expect(mockToast).toBeCalledWith("MenuItemReview Updated - id: 1 itemId: 2 reviewerEmail: test2@ucsb.edu stars: 4 dateReviewed: 2023-08-05T03:58:55.563Z comments: This is a test review 2");
-            expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview"});
-        });
-
-        test("Changes when you click Update", async () => {
             
             render(
                 <QueryClientProvider client={queryClient}>
@@ -185,13 +145,23 @@ describe("MenuItemReviewEditPage tests", () => {
             fireEvent.change(starsField, { target: { value: newStars } });
             fireEvent.change(dateReviewedField, { target: { value: newDateReviewed } });
             fireEvent.change(commentsField, { target: { value: newComments } });
-            
+
             const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());
             expect(mockToast).toBeCalledWith(`MenuItemReview Updated - id: 1 itemId: ${newItemId} reviewerEmail: ${newReviewerEmail} stars: ${newStars} dateReviewed: ${newDateReviewed} comments: ${newComments}`);
             expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview"});
+
+            expect(axiosMock.history.put.length).toBe(1); // one call
+            expect(axiosMock.history.put[0].params).toEqual({ id: 1 });
+            expect(JSON.parse(axiosMock.history.put[0].data)).toEqual({
+                "itemId": newItemId,
+                "reviewerEmail": newReviewerEmail,
+                "stars": newStars,
+                "dateReviewed": newDateReviewed,
+                "comments": newComments
+            });
         });
     });
 });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,44 +1,142 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 1
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("MenuItemReviewEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/menuitemreview").timeout();
+        });
 
-        setupUserOnly();
-
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+            const restoreConsole = mockConsole();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit MenuItemReview");
+            restoreConsole();
+        });
     });
 
+    /*
+        Example:
+        {
+        "id": 1,
+        "itemId": 1,
+        "reviewerEmail": "test@ucsb.edu",
+        "stars": 5,
+        "dateReviewed": "2023-08-05T03:58:55.563Z",
+        "comments": "This is a test review"
+        },
+    */
+    describe("tests where backend is working normally", () => {
+        const axiosMock = new AxiosMockAdapter(axios);
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/menuitemreview").reply(200, {
+                "id": 1,
+                "itemId": 1,
+                "reviewerEmail": "test@ucsb.edu",
+                "stars": 5,
+                "dateReviewed": "2023-08-05T03:58:55.563Z",
+                "comments": "This is a test review"
+            });
+            axiosMock.onPut("/api/menuitemreview").reply(200, {
+                "id": 1,
+                "itemId": 1,
+                "reviewerEmail": "test@ucsb.edu",
+                "stars": 5,
+                "dateReviewed": "2023-08-05T03:58:55.563Z",
+                "comments": "This is a test review 2"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("Is populated with the data provided", async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("MenuItemReviewForm-id");
+
+            const idField = screen.getByTestId("MenuItemReviewForm-id");
+            const itemIdField = screen.getByTestId("MenuItemReviewForm-item-id");
+            const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewer-email");
+            const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+            const dateReviewedField = screen.getByTestId("MenuItemReviewForm-date-reviewed");
+            const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+            
+            expect(idField).toBeInTheDocument();
+            expect(itemIdField).toBeInTheDocument();
+            expect(reviewerEmailField).toBeInTheDocument();
+            expect(starsField).toBeInTheDocument();
+            expect(dateReviewedField).toBeInTheDocument();
+            expect(commentsField).toBeInTheDocument();
+
+            expect(idField).toHaveValue("1");
+            expect(itemIdField).toHaveValue("1");
+            expect(reviewerEmailField).toHaveValue("test@ucsb.edu");
+            expect(starsField).toHaveValue("5");
+            expect(dateReviewedField).toHaveValue("2023-08-05T03:58:55.563Z");
+            expect(commentsField).toHaveValue("This is a test review");
+        
+            const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+            fireEvent.change(commentsField, { target: { value: "This is a test review 2" } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("MenuItemReview Updated - id: 1 itemId: 1 reviewerEmail: test@ucsb.edu stars: 5 dateReviewed: 2023-08-05T03:58:55.563Z comments: This is a test review 2");
+            expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview"});
+        });
+    });
 });
-
-

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -43,7 +43,7 @@ describe("MenuItemReviewEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-            axiosMock.onGet("/api/menuitemreview").timeout();
+            axiosMock.onGet("/api/menuitemreview", {params: {id: 1}}).timeout();
         });
 
         const queryClient = new QueryClient();
@@ -57,6 +57,7 @@ describe("MenuItemReviewEditPage tests", () => {
                 </QueryClientProvider>
             );
             await screen.findByText("Edit MenuItemReview");
+            expect(screen.queryByTestId("MenuItemReview-name")).not.toBeInTheDocument();
             restoreConsole();
         });
     });
@@ -79,7 +80,7 @@ describe("MenuItemReviewEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-            axiosMock.onGet("/api/menuitemreview").reply(200, {
+            axiosMock.onGet("/api/menuitemreview", {params: {id: 1}}).reply(200, {
                 "id": 1,
                 "itemId": 1,
                 "reviewerEmail": "test@ucsb.edu",
@@ -89,9 +90,9 @@ describe("MenuItemReviewEditPage tests", () => {
             });
             axiosMock.onPut("/api/menuitemreview").reply(200, {
                 "id": 1,
-                "itemId": 1,
-                "reviewerEmail": "test@ucsb.edu",
-                "stars": 5,
+                "itemId": 2,
+                "reviewerEmail": "test2@ucsb.edu",
+                "stars": 4,
                 "dateReviewed": "2023-08-05T03:58:55.563Z",
                 "comments": "This is a test review 2"
             });
@@ -135,7 +136,61 @@ describe("MenuItemReviewEditPage tests", () => {
             fireEvent.click(submitButton);
 
             await waitFor(() => expect(mockToast).toBeCalled());
-            expect(mockToast).toBeCalledWith("MenuItemReview Updated - id: 1 itemId: 1 reviewerEmail: test@ucsb.edu stars: 5 dateReviewed: 2023-08-05T03:58:55.563Z comments: This is a test review 2");
+            expect(mockToast).toBeCalledWith("MenuItemReview Updated - id: 1 itemId: 2 reviewerEmail: test2@ucsb.edu stars: 4 dateReviewed: 2023-08-05T03:58:55.563Z comments: This is a test review 2");
+            expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview"});
+        });
+
+        test("Changes when you click Update", async () => {
+            
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("MenuItemReviewForm-id");
+
+            const idField = screen.getByTestId("MenuItemReviewForm-id");
+            const itemIdField = screen.getByTestId("MenuItemReviewForm-item-id");
+            const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewer-email");
+            const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+            const dateReviewedField = screen.getByTestId("MenuItemReviewForm-date-reviewed");
+            const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+
+            expect(idField).toBeInTheDocument();
+            expect(itemIdField).toBeInTheDocument();
+            expect(reviewerEmailField).toBeInTheDocument();
+            expect(starsField).toBeInTheDocument();
+            expect(dateReviewedField).toBeInTheDocument();
+            expect(commentsField).toBeInTheDocument();
+
+            expect(idField).toHaveValue("1");
+            expect(itemIdField).toHaveValue("1");
+            expect(reviewerEmailField).toHaveValue("test@ucsb.edu");
+            expect(starsField).toHaveValue("5");
+            expect(dateReviewedField).toHaveValue("2023-08-05T03:58:55.563Z");
+            expect(commentsField).toHaveValue("This is a test review");
+
+            const newItemId = "2";
+            const newReviewerEmail = "test2@ucsb.edu";
+            const newStars = "4";
+            const newDateReviewed = "2023-08-05T03:58:55.563Z";
+            const newComments = "This is a test review 2";
+
+            // change all the fields
+            fireEvent.change(itemIdField, { target: { value: newItemId } });
+            fireEvent.change(reviewerEmailField, { target: { value: newReviewerEmail } });
+            fireEvent.change(starsField, { target: { value: newStars } });
+            fireEvent.change(dateReviewedField, { target: { value: newDateReviewed } });
+            fireEvent.change(commentsField, { target: { value: newComments } });
+            
+            const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith(`MenuItemReview Updated - id: 1 itemId: ${newItemId} reviewerEmail: ${newReviewerEmail} stars: ${newStars} dateReviewed: ${newDateReviewed} comments: ${newComments}`);
             expect(mockNavigate).toBeCalledWith({ to: "/menuitemreview"});
         });
     });

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,19 +1,30 @@
-import { render, screen, waitFor} from "@testing-library/react";
+import { render, screen, waitFor, fireEvent} from "@testing-library/react";
 import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
+import mockConsole from "jest-mock-console";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("MenuItemReviewIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+    const testId = "MenuItemReviewTable";
 
-    const _setupUserOnly = () => {
+    const setupUserOnly = () => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
@@ -53,6 +64,71 @@ describe("MenuItemReviewIndexPage tests", () => {
         expect(button).toHaveAttribute("style", "float: right;");
     });
 
+    test("renders three menuitemreviews correctly for regular user", async () => {
+        setupUserOnly();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        const createButton = screen.queryByText("Create MenuItemReview");
+        expect(createButton).not.toBeInTheDocument();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`)).not.toBeInTheDocument();
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/menuitemreview/all");
+        restoreConsole();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.threeMenuItemReviews);
+        axiosMock.onDelete("/api/menuitemreview").reply(200, "MenuItemReview with id 1 was deleted");
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+        expect(mockToast).toHaveBeenCalledWith("MenuItemReview with id 1 was deleted");
+    });
 });
-
-

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/menuItemReviewUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("MenuItemReviewUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/menuitemreview",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
## Overview
This PR adds implementation for create and edit pages for MenuItemReview with tests and storybook.

One commit fix the wrong delete endpoint.

## Screenshots

## Test Coverage
Tests passed with 100% coverage and mutation

## Links to issues
Closes #38 
Closed #36 
